### PR TITLE
Let BeatError extend from Exception

### DIFF
--- a/cronus/beat.py
+++ b/cronus/beat.py
@@ -49,7 +49,7 @@ def true():
     return True
 
 
-class BeatError:
+class BeatError(Exception):
 
     def __init__(self, msg):
         self.msg = msg


### PR DESCRIPTION
BeatError was not extending Exception. When raising BeatError it would throw TypeError: exceptions must derive from BaseException. This should not happen anymore.
