### PR TITLE
moved into a class, so multiple frequencies can be created

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ As of now, Cronus implements two features:
 * Allows a continuous while loop to run at a fixed frequency
 
 ```python
-import cronus.beat as beat
+from cronus.beat import Beat
 import time
 import datetime
 
@@ -31,6 +31,7 @@ def do_some_work():
 
 if __name__ == "__main__":
     # specify rate in Hz
+    beat = Beat()
     beat.set_rate(2)
     while beat.true():
         do_some_work()

--- a/cronus/beat.py
+++ b/cronus/beat.py
@@ -7,46 +7,51 @@ Date created: 19th May 2014
 import datetime
 import time
 
-loop_start_time = None
-loop_duration = 0
 
-def set_rate(rate):
-    """Defines the ideal rate at which computation is to be performed
 
-    :arg rate: the frequency in Hertz 
-    :type rate: int or float
 
-    :raises: TypeError: if argument 'rate' is not int or float
-    """
-    if not (isinstance(rate, int) or isinstance(rate, float)):
-        raise TypeError("argument to set_rate is expected to be int or float")
-    global loop_duration
-    loop_duration = 1.0/rate
+class Beat():
+	def __init__(self):
+		self.loop_start_time = None
+		self.loop_duration = 0
 
-def sleep():
-    """Sleeps for a dynamic duration of time as determined by set_rate() and true().
-    
-    :raises: BeatError: if this function is called before calling set_rate() or \
-            before calling true()
-    """
-    if loop_duration == 0:
-        raise BeatError("call beat.set_rate() before calling sleep")
-    if loop_start_time == None:
-        raise BeatError("call beat.true() before calling sleep")
-    td = datetime.datetime.now() - loop_start_time
-    duration_to_sleep = loop_duration - td.total_seconds()
-    if duration_to_sleep < 0:
-        raise BeatError("skipping sleep. Too much work!")
-    time.sleep(duration_to_sleep)
+	def set_rate(self,rate):
+		"""Defines the ideal rate at which computation is to be performed
 
-def true():
-    """A substitute to True. Use 'while beat.true()' instead of 'while True'
-    
-    :returns: True
-    """
-    global loop_start_time
-    loop_start_time = datetime.datetime.now()
-    return True
+		:arg rate: the frequency in Hertz 
+		:type rate: int or float
+
+		:raises: TypeError: if argument 'rate' is not int or float
+		"""
+		if not (isinstance(rate, int) or isinstance(rate, float)):
+			raise TypeError("argument to set_rate is expected to be int or float")
+
+		self.loop_duration = 1.0/rate
+
+	def sleep(self):
+		"""Sleeps for a dynamic duration of time as determined by set_rate() and true().
+		
+		:raises: BeatError: if this function is called before calling set_rate() or \
+				before calling true()
+		"""
+		if self.loop_duration == 0:
+			raise BeatError("call beat.set_rate() before calling sleep")
+		if self.loop_start_time == None:
+			raise BeatError("call beat.true() before calling sleep")
+		td = datetime.datetime.now() - self.loop_start_time
+		duration_to_sleep = self.loop_duration - td.total_seconds()
+		if duration_to_sleep < 0:
+			raise BeatError("skipping sleep. Too much work!")
+		time.sleep(duration_to_sleep)
+
+	def true(self):
+		"""A substitute to True. Use 'while beat.true()' instead of 'while True'
+		
+		:returns: True
+		"""
+
+		self.loop_start_time = datetime.datetime.now()
+		return True
 
 
 class BeatError(Exception):


### PR DESCRIPTION
Implementing it as a class rather than a module would allow to define multiple frequencies in parallel threads. The syntax need not change much.

Use case:

```
from cronus.beat import Beat
import time
import datetime
import threading

def do_some_work():
    beat = Beat()
    beat.set_rate(2)
    while beat.true():
        print (datetime.datetime.now(), "doing work")
        beat.sleep()
        
def do_some_work2():
    beat = Beat()
    beat.set_rate(10)
    while beat.true():
        print (datetime.datetime.now(), "doing work2")
        beat.sleep()
if __name__ == "__main__":

    t1 = threading.Thread(target = do_some_work)
    t2 = threading.Thread(target = do_some_work2)
    t1.start()
    t2.start()
    t1.join()
```